### PR TITLE
fix: Node.js 18 compatibility and deploy fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,7 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           password: ${{ secrets.SSH_PASSWORD }}
           script: |
+            set -e
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm use 18

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "md5": ">=2.0.0",
         "morgan": "~1.10.0",
         "nodemailer": "^8.0.7",
-        "password-generator": "^3.0.0",
+        "password-generator": "^2.3.2",
         "pg": "^8.20.0",
         "pg-hstore": "^2.3.4",
         "pug": "^3.0.3",
@@ -43,7 +43,7 @@
         "pug-lint": "^2.7.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -3278,15 +3278,11 @@
       }
     },
     "node_modules/password-generator": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/password-generator/-/password-generator-3.0.0.tgz",
-      "integrity": "sha512-si0IXGjiLJBpNYHmowDpti6TKuvvbKVq4HhJPzXp/C+GDGdml8PeUjUZiMGaOwlFNpwDZNRhTVpdGZA3ksVfRQ==",
-      "license": "MIT",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/password-generator/-/password-generator-2.3.2.tgz",
+      "integrity": "sha512-kJWUrdveSAqHCeWJWnv5vNc89hFHM5au+pvKja5+xCTxlRF3zQaecJlR6hSoOotAJtQ3otQq4/Q4iWc/TxsXhA==",
       "bin": {
-        "password-generator": "bin/password-generator.js"
-      },
-      "engines": {
-        "node": ">=20"
+        "password-generator": "bin/password-generator"
       }
     },
     "node_modules/path-exists": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "md5": ">=2.0.0",
     "morgan": "~1.10.0",
     "nodemailer": "^8.0.7",
-    "password-generator": "^3.0.0",
+    "password-generator": "^2.3.2",
     "pg": "^8.20.0",
     "pg-hstore": "^2.3.4",
     "pug": "^3.0.3",


### PR DESCRIPTION
- downgrade password-generator 3.0.0 → 2.3.2 (v3 requires Node >=20)
- add set -e to SSH script so deploy fails fast on any error
- add vars.APP_PATH for absolute server path in SSH script
- node-version 22 → 18 in CI/CD lint job
- nvm use 22 → 18 in SSH deploy script
- .nvmrc: 22 → 18, package.json engines: >=22 → >=18
- README: document Node.js 18 constraint, APP_PATH variable, modernization history and technical debt