### PR TITLE
fix: emailjs v5 → v4, pm2 delete+start in deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,8 +89,6 @@ jobs:
             cd ${{ vars.APP_PATH }}
             npm ci --omit=dev
             APP="${{ vars.PM2_APP_NAME }}"
-            if pm2 describe "$APP" > /dev/null 2>&1; then
-              pm2 restart "$APP"
-            else
-              pm2 start app.js --name "$APP"
-            fi
+            pm2 delete "$APP" 2>/dev/null || true
+            pm2 start app.js --name "$APP"
+            pm2 save

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "cookie-parser": "~1.4.7",
         "debug": "~4.4.0",
         "dotenv": "^16.0.0",
-        "emailjs": "^5.0.0",
+        "emailjs": "^4.0.3",
         "excel4node": "^1.8.2",
         "express": "^4.22.2",
         "express-flash": "0.0.2",
@@ -1294,15 +1294,15 @@
       "license": "MIT"
     },
     "node_modules/emailjs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/emailjs/-/emailjs-5.0.0.tgz",
-      "integrity": "sha512-J7gxswcLGRZQM+HQBgll0DJuEMFiJIa7UzgK3GsjlytyRS4X2z7K1brQLlezEs3ul+jqvYYoCTqPAgWrVZf0mw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/emailjs/-/emailjs-4.0.3.tgz",
+      "integrity": "sha512-1CDXoE3FxkSg7QRTlLsDCYG9elFNu/JQsYWu3Xfrk77ubbg5zYgFGg+JRUKQJ56mceM8o3rHHX0VB4wo9XsyLQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       },
       "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=4.3.5"
       },
       "peerDependenciesMeta": {
         "typescript": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dotenv": "^16.0.0",
     "cookie-parser": "~1.4.7",
     "debug": "~4.4.0",
-    "emailjs": "^5.0.0",
+    "emailjs": "^4.0.3",
     "excel4node": "^1.8.2",
     "express": "^4.22.2",
     "express-flash": "0.0.2",


### PR DESCRIPTION
- downgrade emailjs ^5.0.0 → ^4.0.3 (v5 is ESM-only, incompatible with CommonJS require)
- replace pm2 restart with delete+start+save in SSH deploy script to avoid stale cwd and immutable environment issues
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>