### PR TITLE
fix: replace emailjs with nodemailer in mailer.js

### DIFF
--- a/lib/services/mailer.js
+++ b/lib/services/mailer.js
@@ -1,27 +1,30 @@
 var models = require('../models');
 var md5 = require('md5');
 var generatePassword = require('password-generator');
-var email = require('emailjs');
+var nodemailer = require('nodemailer');
 var config = require('../config');
 
 /**
  * Set main transporter(sender)
  */
-var transporter ={};
+var transporter = {};
 
 transporter.sendMail = function (mailOptions, resultHandler) {
-  var server  = email.server.connect({
-    user: config.transporterMail,
-    password: config.transporterPassword,
+  var transport = nodemailer.createTransport({
     host: config.transporterHost,
-    ssl: config.transporterSSL || false
+    port: config.transporterSSL ? 465 : 587,
+    secure: config.transporterSSL || false,
+    auth: {
+      user: config.transporterMail,
+      pass: config.transporterPassword
+    }
   });
 
-  server.send({
-   text:    mailOptions.text,
-   from:    mailOptions.from,
-   to:      mailOptions.to,
-   subject: mailOptions.subject
+  transport.sendMail({
+    from: mailOptions.from,
+    to: mailOptions.to,
+    subject: mailOptions.subject,
+    text: mailOptions.text
   }, resultHandler);
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "cookie-parser": "~1.4.7",
         "debug": "~4.4.0",
         "dotenv": "^16.0.0",
-        "emailjs": "^4.0.3",
         "excel4node": "^1.8.2",
         "express": "^4.22.2",
         "express-flash": "0.0.2",
@@ -1292,23 +1291,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
-    },
-    "node_modules/emailjs": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/emailjs/-/emailjs-4.0.3.tgz",
-      "integrity": "sha512-1CDXoE3FxkSg7QRTlLsDCYG9elFNu/JQsYWu3Xfrk77ubbg5zYgFGg+JRUKQJ56mceM8o3rHHX0VB4wo9XsyLQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.3.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "dotenv": "^16.0.0",
     "cookie-parser": "~1.4.7",
     "debug": "~4.4.0",
-    "emailjs": "^4.0.3",
     "excel4node": "^1.8.2",
     "express": "^4.22.2",
     "express-flash": "0.0.2",


### PR DESCRIPTION
emailjs v4+ is ESM-only, incompatible with CommonJS require(). nodemailer was already in dependencies but unused. Rewrote mailer.js transporter to use nodemailer.createTransport()